### PR TITLE
Add simplify Linear Combination method

### DIFF
--- a/src/r1cs/linear_combination.rs
+++ b/src/r1cs/linear_combination.rs
@@ -5,7 +5,7 @@ use std::iter::FromIterator;
 use std::ops::{Add, Mul, Neg, Sub};
 
 /// Represents a variable in a constraint system.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Variable {
     /// Represents an external input specified by a commitment.
     Committed(usize),
@@ -193,5 +193,27 @@ impl<S: Into<Scalar>> Mul<S> for LinearCombination {
             *s *= other
         }
         self
+    }
+}
+
+impl LinearCombination {
+    /// Taken from lovesh's fork of bulletproof
+    /// Simplify linear combination by taking Variables common across terms and adding their corresponding scalars.
+    /// Useful when linear combinations become large. Takes ownership of linear combination as this function is useful
+    /// when memory is limited and the obvious action after this function call will be to free the memory held by the old linear combination
+    pub fn simplify(self) -> Self {
+        // Build hashmap to hold unique variables with their values.
+        let mut vars: HashMap<Variable, Scalar> = HashMap::new();
+
+        let terms = self.terms;
+        for (var, val) in terms {
+            *vars.entry(var).or_insert(Scalar::zero()) += val;
+        }
+
+        let mut new_lc_terms = vec![];
+        for (var, val) in vars {
+            new_lc_terms.push((var, val));
+        }
+        new_lc_terms.iter().collect()
     }
 }

--- a/src/r1cs/linear_combination.rs
+++ b/src/r1cs/linear_combination.rs
@@ -1,6 +1,7 @@
 //! Definition of linear combinations.
 
 use curve25519_dalek::scalar::Scalar;
+use std::collections::HashMap;
 use std::iter::FromIterator;
 use std::ops::{Add, Mul, Neg, Sub};
 

--- a/src/r1cs/prover.rs
+++ b/src/r1cs/prover.rs
@@ -44,7 +44,8 @@ pub struct Prover<'t, 'g, G: CommitmentGenerator> {
 
     /// This list holds closures that will be called in the second phase of the protocol,
     /// when non-randomized variables are committed.
-    deferred_constraints: Vec<Box<dyn Fn(&mut RandomizingProver<'t, 'g, G>) -> Result<(), R1CSError>>>,
+    deferred_constraints:
+        Vec<Box<dyn Fn(&mut RandomizingProver<'t, 'g, G>) -> Result<(), R1CSError>>>,
 
     /// Index of a pending multiplier that's not fully assigned yet.
     pending_multiplier: Option<usize>,

--- a/src/r1cs/verifier.rs
+++ b/src/r1cs/verifier.rs
@@ -324,9 +324,11 @@ impl<'t> Verifier<'t> {
         proof: &R1CSProof,
         pc_gens: &PedersenGens,
         bp_gens: &BulletproofGens,
-        thread_rng: &mut R) -> Result<(), R1CSError>
-        where
-            R: rand::Rng + rand::CryptoRng    {
+        thread_rng: &mut R,
+    ) -> Result<(), R1CSError>
+    where
+        R: rand::Rng + rand::CryptoRng,
+    {
         // Commit a length _suffix_ for the number of high-level variables.
         // We cannot do this in advance because user can commit variables one-by-one,
         // but this suffix provides safe disambiguation because each variable

--- a/tests/r1cs.rs
+++ b/tests/r1cs.rs
@@ -10,8 +10,8 @@ use bulletproofs::{BulletproofGens, PedersenGens};
 use curve25519_dalek::ristretto::CompressedRistretto;
 use curve25519_dalek::scalar::Scalar;
 use merlin::Transcript;
-use rand::thread_rng;
 use rand::seq::SliceRandom;
+use rand::thread_rng;
 
 // Shuffle gadget (documented in markdown file)
 


### PR DESCRIPTION
Idea is to simplify the linear combinations when doing operations such as matrix multiplication.


Function was taken from lovesh's fork.