### PR TITLE
Reintroduce custom `rng` as arg in bulletproofs' methods

### DIFF
--- a/docs/r1cs-docs-example.md
+++ b/docs/r1cs-docs-example.md
@@ -359,6 +359,8 @@ impl ShuffleProof {
         input_commitments: &Vec<CompressedRistretto>,
         output_commitments: &Vec<CompressedRistretto>,
     ) -> Result<(), R1CSError> {
+        let mut rng = rand::thread_rng();
+
         // Apply a domain separator with the shuffle parameters to the transcript
         let k = input_commitments.len();
         transcript.commit_bytes(b"dom-sep", b"ShuffleProof");
@@ -376,7 +378,7 @@ impl ShuffleProof {
 
         ShuffleProof::gadget(&mut verifier, input_vars, output_vars)?;
 
-        verifier.verify(&self.0, &pc_gens, &bp_gens)
+        verifier.verify(&self.0, &pc_gens, &bp_gens, &mut rng)
     }
 }
 ```
@@ -499,6 +501,8 @@ Because only the prover knows the scalar values of the inputs and outputs, and t
 #         input_commitments: &Vec<CompressedRistretto>,
 #         output_commitments: &Vec<CompressedRistretto>,
 #     ) -> Result<(), R1CSError> {
+          let mut rng = rand::thread_rng();
+
 #         // Apply a domain separator with the shuffle parameters to the transcript
 #         let k = input_commitments.len();
 #         transcript.commit_bytes(b"dom-sep", b"ShuffleProof");
@@ -516,7 +520,7 @@ Because only the prover knows the scalar values of the inputs and outputs, and t
 #
 #         ShuffleProof::gadget(&mut verifier, input_vars, output_vars)?;
 #
-#         verifier.verify(&self.0, &pc_gens, &bp_gens)
+#         verifier.verify(&self.0, &pc_gens, &bp_gens, &mut rng)
 #     }
 # }
 # fn main() {

--- a/src/r1cs/verifier.rs
+++ b/src/r1cs/verifier.rs
@@ -327,12 +327,16 @@ impl<'t> Verifier<'t> {
     /// [`BulletproofGens`] should have `gens_capacity` greater than
     /// the number of multiplication constraints that will eventually
     /// be added into the constraint system.
-    pub fn verify(
+    pub fn verify<R>(
         mut self,
         proof: &R1CSProof,
         pc_gens: &PedersenGens,
         bp_gens: &BulletproofGens,
-    ) -> Result<(), R1CSError> {
+        thread_rng: &mut R,
+    ) -> Result<(), R1CSError>
+    where
+        R: rand::Rng + rand::CryptoRng,
+    {
         // Commit a length _suffix_ for the number of high-level variables.
         // We cannot do this in advance because user can commit variables one-by-one,
         // but this suffix provides safe disambiguation because each variable
@@ -445,8 +449,7 @@ impl<'t> Verifier<'t> {
         // Create a `TranscriptRng` from the transcript. The verifier
         // has no witness data to commit, so this just mixes external
         // randomness into the existing transcript.
-        use rand::thread_rng;
-        let mut rng = self.transcript.build_rng().finalize(&mut thread_rng());
+        let mut rng = self.transcript.build_rng().finalize(thread_rng);
         let r = Scalar::random(&mut rng);
 
         let xx = x * x;

--- a/tests/r1cs.rs
+++ b/tests/r1cs.rs
@@ -119,6 +119,8 @@ impl ShuffleProof {
         input_commitments: &Vec<CompressedRistretto>,
         output_commitments: &Vec<CompressedRistretto>,
     ) -> Result<(), R1CSError> {
+        let mut rng = rand::thread_rng();
+
         // Apply a domain separator with the shuffle parameters to the transcript
         // XXX should this be part of the gadget?
         let k = input_commitments.len();
@@ -139,7 +141,7 @@ impl ShuffleProof {
 
         ShuffleProof::gadget(&mut verifier, input_vars, output_vars)?;
 
-        verifier.verify(&self.0, &pc_gens, &bp_gens)
+        verifier.verify(&self.0, &pc_gens, &bp_gens, &mut rng)
     }
 }
 
@@ -284,6 +286,8 @@ fn example_gadget_verify(
     proof: R1CSProof,
     commitments: Vec<CompressedRistretto>,
 ) -> Result<(), R1CSError> {
+    let mut rng = rand::thread_rng();
+
     let mut transcript = Transcript::new(b"R1CSExampleGadget");
 
     // 1. Create a verifier
@@ -305,7 +309,7 @@ fn example_gadget_verify(
 
     // 4. Verify the proof
     verifier
-        .verify(&proof, &pc_gens, &bp_gens)
+        .verify(&proof, &pc_gens, &bp_gens, &mut rng)
         .map_err(|_| R1CSError::VerificationError)
 }
 
@@ -419,6 +423,8 @@ fn range_proof_gadget() {
 }
 
 fn range_proof_helper(v_val: u64, n: usize) -> Result<(), R1CSError> {
+    let mut rng = rand::thread_rng();
+
     // Common
     let pc_gens = PedersenGens::default();
     let bp_gens = BulletproofGens::new(128, 1);
@@ -449,5 +455,5 @@ fn range_proof_helper(v_val: u64, n: usize) -> Result<(), R1CSError> {
     assert!(range_proof(&mut verifier, var.into(), None, n).is_ok());
 
     // Verifier verifies proof
-    Ok(verifier.verify(&proof, &pc_gens, &bp_gens)?)
+    Ok(verifier.verify(&proof, &pc_gens, &bp_gens, &mut rng)?)
 }


### PR DESCRIPTION
Custom rng are needed for porting flexibility (e.g. to compile
bulletproofs in WASM as is, without wasm-bindgen)

Resolves: dusk-network/phoenix#21